### PR TITLE
Ampliación de la previsión del tiempo a 7 días

### DIFF
--- a/app.py
+++ b/app.py
@@ -1932,7 +1932,7 @@ def api_weather():
 
     # Días opcionales (?days=3..16); por defecto 5
     try:
-        days = int(request.args.get("days") or 5)
+        days = int(request.args.get("days") or 8)
         if days < 1: days = 1
         if days > 16: days = 16
     except Exception:

--- a/static/weather/weather.js
+++ b/static/weather/weather.js
@@ -19,7 +19,7 @@
   const DEFAULT_LAT = 40.4168; // Madrid
   const DEFAULT_LON = -3.7038;
 
-  async function loadWeather(lat = DEFAULT_LAT, lon = DEFAULT_LON, days = 5) {
+  async function loadWeather(lat = DEFAULT_LAT, lon = DEFAULT_LON, days = 8) {
     const u = new URL('/api/weather', location.origin);
     u.searchParams.set('lat', lat);
     u.searchParams.set('lon', lon);


### PR DESCRIPTION
Modificación de 'weather.js' y de 'app.py' para que se recupere la previsión de los próximos 7 días (más la de hoy), en lugar de sólo la previsión de los próximos 4 días (más la de hoy), y ésta previsión extendida se muestre por pantalla al hacer clic en el widget del tiempo.