### PR TITLE
Ajustes para ver el widget del tiempo en la web de Render.

### DIFF
--- a/static/weather/weather.css
+++ b/static/weather/weather.css
@@ -3,7 +3,7 @@
   position: fixed;
   left: 24px;
   bottom: 24px;
-  z-index: 1000; /* por debajo del launcher del chat (100001), y por encima del mapa */
+  z-index: 100050; /* por encima del iframe del mapa y del panel lateral */
   display: flex;
   flex-direction: column-reverse; /* botón abajo, panel se abre hacia arriba */
   align-items: flex-start;

--- a/templates/index.html
+++ b/templates/index.html
@@ -214,7 +214,7 @@
       </div>
       <ul id="wx-days" class="wx-days"></ul>
       <div class="wx-foot">
-        <small>Datos: <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open‑Meteo</a></small>
+        <small>Datos: <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo</a></small>
       </div>
     </div>
 
@@ -223,6 +223,7 @@
       <span id="wx-emoji" aria-hidden="true">⛅</span>
     </button>
   </div>
+
 
 
   <!-- JS del launcher -->


### PR DESCRIPTION
Ligeros ajustes en 'index.html' y 'weather.css' para que el widget del tiempo se vea en la web de Render.